### PR TITLE
Remove RPATH/RUNPATH from ROCm libraries and binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE CACHE BOOL "Do not add paths to linker search and installed rpath")
 
 # Set the default value of BUILD_SHARED_LIBS
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker search and installed rpath")
 
 # Set the default value of BUILD_SHARED_LIBS
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared")

--- a/install
+++ b/install
@@ -114,11 +114,6 @@ if [[ "${build_relocatable}" == true ]]; then
     if ! [ -z ${ROCM_PATH+x} ]; then
         rocm_path=${ROCM_PATH}
     fi
-
-    rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib:/opt/rocm/lib64"
-    if ! [ -z ${ROCM_RPATH+x} ]; then
-        rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,${ROCM_RPATH}"
-    fi
 fi
 
 # Instal the pre-commit hook
@@ -183,7 +178,7 @@ if [[ "${build_relocatable}" == true ]]; then
     CXX=${rocm_path}/bin/$compiler ${cmake_executable}  -DCMAKE_INSTALL_PREFIX="${rocm_path}" \
     -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON ${cmake_common_options} \
     -DCMAKE_PREFIX_PATH="${rocm_path};${rocm_path}/hcc;${rocm_path}/hip" \
-    -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" \
+    -DCMAKE_SKIP_INSTALL_RPATH=TRUE \
     -DROCM_DISABLE_LDCONFIG=ON \
     -DCMAKE_MODULE_PATH="${rocm_path}/lib/cmake/hip;${rocm_path}/hip/cmake" \
     ../../. # or cmake-gui ../.

--- a/library/src/fortran/CMakeLists.txt
+++ b/library/src/fortran/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
     target_link_libraries(rocrand_fortran
         PRIVATE
             rocrand
-            "-L${HIP_ROOT_DIR}/lib -lhip_hcc -Wl,-rpath,${HIP_ROOT_DIR}/lib"
+            "-L${HIP_ROOT_DIR}/lib -lhip_hcc"
     )
 endif()
 

--- a/test/package/CMakeLists.txt
+++ b/test/package/CMakeLists.txt
@@ -106,7 +106,7 @@ foreach(test_src ${rocrand_pkg_TEST_SRCS})
         target_link_libraries(${test_name}
             PRIVATE
                 roc::rocrand
-                "-L${HIP_ROOT_DIR}/lib -Wl,-rpath,${HIP_ROOT_DIR}/lib"
+                "-L${HIP_ROOT_DIR}/lib"
         )
     endif()
     add_relative_test(${test_name} ${test_name})


### PR DESCRIPTION
SWDEV-310152:
- Single version package: add ldconfig, no RPATH/RUNPATH in either binaries or libraries
- Multi version package: use RPATH for binaries, no RPATH/RUNPATH for libraries
- amdclang/clang/hipcc compilers shall not add RPATH/RUNPATH to produced binaries or libraries unless explicitly requested by an option
- Versioning scripts will take care of adding rpath to binaries for multi version package